### PR TITLE
Update for_recoveryRBM.m

### DIFF
--- a/modeling/for_recoveryRBM.m
+++ b/modeling/for_recoveryRBM.m
@@ -61,7 +61,7 @@ df_model = table();
 if est_vars.which_vars.omikron_0
    df_model.omikron_0 = rand(n_subj,1) * 10 + 3;
 else
- df_model.omikron_1 = zeros(n_subj, 1);
+ df_model.omikron_0 = zeros(n_subj, 1);
 end
 
 if est_vars.which_vars.omikron_1


### PR DESCRIPTION
Seems like there is a typo here, such that if omicron_0 is not estimated, it's not included into parameters, which will lead to for_task_agent_int, line residual_fun(abs_pred_up, sel_coeffs(1), sel_coeffs(2)) select omicron_1 and h instead of omicron_0 and omicron_1